### PR TITLE
feat: generate static params for chat pages

### DIFF
--- a/src/app/(app)/chat/[id]/page.tsx
+++ b/src/app/(app)/chat/[id]/page.tsx
@@ -1,7 +1,23 @@
-
+import { adminDb } from "@/lib/firebase/admin-config";
 import ClientView from "./ClientView";
 
-export default async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  try {
+    const snapshot = await adminDb.collection("chats").get();
+    return snapshot.docs.map((doc) => ({ id: doc.id }));
+  } catch (error) {
+    console.error("Failed to fetch chat IDs", error);
+    return [];
+  }
+}
+
+export default async function ChatPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   const { id } = await params;
   return <ClientView id={id} />;
 }


### PR DESCRIPTION
## Summary
- generate static params for chat routes from Firestore
- mark chat routes as not accepting dynamic params

## Testing
- `CI=1 npm run build` *(fails: Page "/games/rally/[id]" missing generateStaticParams())*
- `CI=1 npm run build:aab` *(fails: Page "/games/rally/[id]" missing generateStaticParams())*


------
https://chatgpt.com/codex/tasks/task_e_6895e6d149488325bba9bd86d5adfa9d