### PR TITLE
Disable avatar optimization and enable Android geolocation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.taivas.rackt">
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+</manifest>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  images: { unoptimized: true },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/android": "^7.4.2",
         "@capacitor/cli": "^7.4.2",
         "@capacitor/core": "^7.4.2",
+        "@capacitor/geolocation": "^7.1.4",
         "@genkit-ai/firebase": "^1.15.5",
         "@genkit-ai/googleai": "^1.15.5",
         "@genkit-ai/next": "^1.15.5",
@@ -161,6 +162,24 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/@capacitor/geolocation": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-7.1.4.tgz",
+      "integrity": "sha512-8KQfa1RNVmgFoDYYaf13qDuf5rh7ob4mC/zRpzpavPEFhWkuIbFM5dyNpSndc9EFnaIib8BCIjJj9ZQ6+nPrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@capacitor/android": "^7.4.2",
     "@capacitor/cli": "^7.4.2",
     "@capacitor/core": "^7.4.2",
+    "@capacitor/geolocation": "^7.1.4",
     "@genkit-ai/firebase": "^1.15.5",
     "@genkit-ai/googleai": "^1.15.5",
     "@genkit-ai/next": "^1.15.5",

--- a/src/app/(app)/challenges/page.tsx
+++ b/src/app/(app)/challenges/page.tsx
@@ -31,7 +31,7 @@ export default function ChallengesPage() {
   const [open, setOpen] = useState<OpenChallenge[]>([]);
   const [myOpen, setMyOpen] = useState<OpenChallenge[]>([]);
   const [radius, setRadius] = useState(25);
-  const { latitude, longitude, requestLocation } = useUserLocation();
+  const { latitude, longitude, enableLocation } = useUserLocation();
 
   const fetchChallenges = useCallback(async (lat?: number, lng?: number) => {
     if (!user) return;
@@ -88,7 +88,7 @@ export default function ChallengesPage() {
         />
         <LocationGate
           title="Enable location to see nearby challenges."
-          onEnable={requestLocation}
+          onEnable={enableLocation}
           onManual={() => fetchChallenges()}
           onSkip={() => fetchChallenges()}
         />

--- a/src/app/(app)/courts/page.tsx
+++ b/src/app/(app)/courts/page.tsx
@@ -77,7 +77,7 @@ const FilterPanel = ({
 
 
 export default function CourtsMapPage() {
-  const { latitude, longitude, error: locationError, loading: locationLoading, requestLocation } = useUserLocation();
+  const { latitude, longitude, error: locationError, loading: locationLoading, enableLocation } = useUserLocation();
   const { user } = useAuth();
   
   const [courts, setCourts] = useState<Court[]>([]);
@@ -204,7 +204,7 @@ export default function CourtsMapPage() {
         <PageHeader title="Find Courts" description="Search for nearby courts." />
         <LocationGate
           title="Enable location to find nearby courts."
-          onEnable={requestLocation}
+          onEnable={enableLocation}
           onManual={() => {}}
           onSkip={() => {}}
         />

--- a/src/components/profile/edit-profile-dialog.tsx
+++ b/src/components/profile/edit-profile-dialog.tsx
@@ -196,7 +196,7 @@ export function EditProfileDialog({ children, user }: EditProfileDialogProps) {
 
         <div className="flex justify-center items-center h-40 bg-muted rounded-md my-4">
             {previewSrc ? (
-                 <Image src={previewSrc} alt="Avatar preview" width={160} height={160} className="h-full w-auto object-contain rounded-md" />
+                 <Image src={previewSrc} alt="Avatar preview" width={160} height={160} className="h-full w-auto object-contain rounded-md" unoptimized />
             ) : (
                 <UserAvatar user={user} className="h-24 w-24" />
             )}
@@ -254,7 +254,7 @@ export function EditProfileDialog({ children, user }: EditProfileDialogProps) {
                             previewUrl === avatar.url ? "border-primary" : "border-transparent"
                         )}
                     >
-                        <Image src={avatar.url} alt="Stock Avatar" width={100} height={100} className="rounded-md aspect-square object-cover" />
+                        <Image src={avatar.url} alt="Stock Avatar" width={100} height={100} className="rounded-md aspect-square object-cover" unoptimized />
                     </button>
                 ))}
             </div>

--- a/src/components/settings/avatar-selector.tsx
+++ b/src/components/settings/avatar-selector.tsx
@@ -71,7 +71,7 @@ export function AvatarSelector({ user }: AvatarSelectorProps) {
                   isSaving && !isBeingProcessed ? "opacity-50 cursor-not-allowed" : ""
                 )}
               >
-                <Image src={avatar.url} alt="Stock Avatar" width={100} height={100} className="rounded-full object-cover w-full h-full" />
+                <Image src={avatar.url} alt="Stock Avatar" width={100} height={100} className="rounded-full object-cover w-full h-full" unoptimized />
                 {isBeingProcessed && (
                   <div className="absolute inset-0 flex items-center justify-center bg-background/80 rounded-full">
                     <LoadingSpinner />

--- a/src/hooks/use-user-location.ts
+++ b/src/hooks/use-user-location.ts
@@ -1,7 +1,11 @@
 
-'use client';
+"use client";
 
 import { useState } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { Geolocation } from '@capacitor/geolocation';
+import { auth, db } from '@/lib/firebase/config';
+import { doc, updateDoc } from 'firebase/firestore';
 
 interface LocationState {
   latitude: number | null;
@@ -18,43 +22,80 @@ export function useUserLocation() {
     loading: false,
   });
 
-  const requestLocation = async () => {
-    if (!navigator.geolocation) {
+  const saveUserLocation = async (lat: number, lng: number) => {
+    const user = auth.currentUser;
+    if (!user) return;
+    try {
+      await updateDoc(doc(db, 'users', user.uid), {
+        latitude: lat,
+        longitude: lng,
+      });
+    } catch (e) {
+      console.error('Failed to save user location', e);
+    }
+  };
+
+  const enableLocation = async () => {
+    setState((prev) => ({ ...prev, loading: true }));
+    try {
+      if (Capacitor.isNativePlatform()) {
+        const perm = await Geolocation.checkPermissions();
+        if (perm.location !== 'granted' && perm.coarseLocation !== 'granted') {
+          await Geolocation.requestPermissions();
+        }
+        const pos = await Geolocation.getCurrentPosition({
+          enableHighAccuracy: true,
+          timeout: 10000,
+        });
+        await saveUserLocation(pos.coords.latitude, pos.coords.longitude);
+        setState({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          error: null,
+          loading: false,
+        });
+      } else if (navigator.geolocation) {
+        await new Promise<void>((resolve) => {
+          navigator.geolocation.getCurrentPosition(
+            (position: GeolocationPosition) => {
+              saveUserLocation(position.coords.latitude, position.coords.longitude);
+              setState({
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+                error: null,
+                loading: false,
+              });
+              resolve();
+            },
+            (error: GeolocationPositionError) => {
+              setState({
+                latitude: null,
+                longitude: null,
+                error: error.message,
+                loading: false,
+              });
+              resolve();
+            },
+            { enableHighAccuracy: true, timeout: 10000 }
+          );
+        });
+      } else {
+        setState({
+          latitude: null,
+          longitude: null,
+          error: 'Geolocation is not supported by your browser.',
+          loading: false,
+        });
+      }
+    } catch (e: any) {
       setState({
         latitude: null,
         longitude: null,
-        error: 'Geolocation is not supported by your browser.',
+        error: e.message ?? String(e),
         loading: false,
       });
-      return;
     }
-
-    setState((prev) => ({ ...prev, loading: true }));
-
-    return new Promise<void>((resolve) => {
-      navigator.geolocation.getCurrentPosition(
-        (position: GeolocationPosition) => {
-          setState({
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-            error: null,
-            loading: false,
-          });
-          resolve();
-        },
-        (error: GeolocationPositionError) => {
-          setState({
-            latitude: null,
-            longitude: null,
-            error: error.message,
-            loading: false,
-          });
-          resolve();
-        },
-        { enableHighAccuracy: true, timeout: 10000 }
-      );
-    });
   };
 
-  return { ...state, requestLocation };
+  return { ...state, enableLocation };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,8 @@ export interface User {
   avatarUrl?: string | null;
   friendIds: string[];
   location?: string;
+  latitude?: number;
+  longitude?: number;
   handPreference?: 'left' | 'right';
   preferredSports: Sport[];
   socials?: Socials;


### PR DESCRIPTION
## Summary
- disable Next.js image optimization so avatars load in Capacitor
- request geolocation permissions via Capacitor and persist user coordinates
- wire challenges and courts location buttons to trigger permission flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898cbccba5483258d3eaade8e08c4f2