### PR TITLE
fix auth redirect for profile and games

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-firebase-hooks": "^5.1.1",
         "react-hook-form": "^7.54.2",
         "recharts": "^2.15.1",
         "tailwind-merge": "^3.0.1",
@@ -13805,6 +13806,16 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-firebase-hooks": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-firebase-hooks/-/react-firebase-hooks-5.1.1.tgz",
+      "integrity": "sha512-y2UpWs82xs+39q5Rc/wq316ca52QsC0n8m801V+yM4IC4hbfOL4yQPVSh7w+ydstdvjN9F+lvs1WrO2VYxpmdA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "firebase": ">= 9.0.0",
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-firebase-hooks": "^5.1.1",
     "react-hook-form": "^7.54.2",
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",

--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -2,18 +2,26 @@
 import { PageHeader } from '@/components/page-header';
 import { Card, CardHeader, CardTitle, CardDescription, CardFooter, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { useAuth } from '@/hooks/use-auth';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth } from '@/lib/firebase/config';
 import { ActiveGamesList } from '@/components/games/active-games-list';
 import { StartLegendSoloDialog } from '@/components/games/start-legend-solo-dialog';
 import { Gamepad2, Brain, Swords, ArrowRight, Users } from 'lucide-react';
 import { StartRallyFriendDialog } from '@/components/games/start-rally-friend-dialog';
 import { Badge } from '@/components/ui/badge';
 import { StartLegendFriendDialog } from '@/components/games/start-legend-friend-dialog';
+import { useRouter } from 'next/navigation';
 
 export default function GamesPage() {
-  const { user } = useAuth();
+  const [user, loading] = useAuthState(auth);
+  const router = useRouter();
 
-  if (!user) return null;
+  if (!loading && !user) {
+    router.replace('/login');
+    return null;
+  }
+
+  if (loading || !user) return <div className="p-4">Loading…</div>;
 
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8">

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,20 +1,20 @@
 'use client';
-import { useAuth } from '@/hooks/use-auth';
+
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth } from '@/lib/firebase/config';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
 export default function ProfileRedirectPage() {
-  const { user, loading } = useAuth();
+  const [user, loading] = useAuthState(auth);
   const router = useRouter();
 
-  useEffect(() => {
-    if (!loading && user) {
-      router.replace(`/profile/${user.uid}`);
-    }
-    if (!loading && !user) {
-        router.replace('/login');
-    }
-  }, [user, loading, router]);
+  if (!loading && !user) {
+    router.replace('/login');
+    return null;
+  }
 
+  if (loading || !user) return <div className="p-4">Loading…</div>;
+
+  router.replace(`/profile/${user.uid}`);
   return null;
 }


### PR DESCRIPTION
## Summary
- use react-firebase-hooks to guard profile and games pages on the client
- redirect unauthenticated users to /login instead of dashboard
- add react-firebase-hooks dependency

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898d4b8b2a083259e24fdd5f5008ec0