### PR TITLE
feat: add user data export

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -16,6 +16,7 @@ import { ThemeSwitcher } from '@/components/settings/theme-switcher';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { AvatarSelector } from '@/components/settings/avatar-selector';
 import { DeleteAccountDialog } from '@/components/settings/delete-account-dialog';
+import { ExportUserData } from '@/components/settings/export-user-data';
 
 export default function SettingsPage() {
   const { user, loading } = useAuth();
@@ -44,7 +45,8 @@ export default function SettingsPage() {
         <SettingsForm user={user} />
         <AvatarSelector user={user} />
         <ThemeSwitcher />
-        
+        <ExportUserData />
+
         <Card>
             <CardHeader>
                 <CardTitle className="flex items-center gap-2"><LogOut /> Log Out</CardTitle>

--- a/src/app/api/export-user-data/route.ts
+++ b/src/app/api/export-user-data/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { adminAuth } from '@/lib/firebase/admin';
+import { exportUserDataAction } from '@/lib/actions';
+
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get('userId');
+    if (!userId) {
+        return new NextResponse('Missing userId', { status: 400 });
+    }
+
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return new NextResponse('Unauthorized', { status: 401 });
+    }
+
+    try {
+        const token = authHeader.split('Bearer ')[1];
+        const decoded = await adminAuth.verifyIdToken(token);
+        if (decoded.uid !== userId) {
+            return new NextResponse('Forbidden', { status: 403 });
+        }
+
+        const data = await exportUserDataAction(userId);
+        return new NextResponse(JSON.stringify(data), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Disposition': `attachment; filename="user-data-${userId}.json"`,
+            },
+        });
+    } catch (error) {
+        console.error('Error exporting user data:', error);
+        return new NextResponse('Unauthorized', { status: 401 });
+    }
+}
+

--- a/src/components/settings/export-user-data.tsx
+++ b/src/components/settings/export-user-data.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card';
+import { useAuth } from '@/hooks/use-auth';
+import { auth } from '@/lib/firebase/config';
+
+export function ExportUserData() {
+  const { user } = useAuth();
+
+  const handleExport = async () => {
+    if (!user || !auth.currentUser) return;
+    try {
+      const token = await auth.currentUser.getIdToken();
+      const res = await fetch(`/api/export-user-data?userId=${user.uid}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (!res.ok) {
+        throw new Error('Failed to export data');
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'user-data.json';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to export data', err);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><Download /> Export Data</CardTitle>
+        <CardDescription>Download a copy of your data.</CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button variant="outline" onClick={handleExport} disabled={!user} className="w-full sm:w-auto">
+          Download JSON
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement action to gather profile, match, friend and chat data for export
- secure API route to authorize user and return downloadable JSON
- add settings UI to trigger export

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a5f105c0288325b55548ae4b4d8c79